### PR TITLE
fix(bin/netsoft-circle): fix NoMethodError in the 'merge' command.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 ### Fixed
 
+## [0.4.0]
+### Fixed
+- correct simplecov merge on newer simplecov release
+
 ## [0.3.9]
 ### Fixed
 - correct API call to github for adding labels and fix logic in determining if we should or should not add the label

--- a/bin/netsoft-circle
+++ b/bin/netsoft-circle
@@ -45,7 +45,7 @@ class NetsoftCircle < Thor # :nodoc:
       json = JSON.parse(File.read(file))
       json.each do |command_name, data|
         result = SimpleCov::Result.from_hash(command_name => data)
-        results << result
+        results.concat [*result]
       end
     end
 

--- a/lib/netsoft-danger/version.rb
+++ b/lib/netsoft-danger/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module NetsoftDanger
-  VERSION = '0.3.9'
+  VERSION = '0.4.0'
 end


### PR DESCRIPTION
[Source](https://tasks.hubstaff.com/app/organizations/55/timeline/projects/315/tasks/775449)

The `.from_hash` method is returning an Array of `SimpleCov::Result`
objects rather than a single `SimpleCov::Result`. We end up appending
this to another array, leaving us with an array of arrays instead of an
array of `SimpleCov::Result` objects as was expected.

The fix switches to `.concat` instead of `<<`, there by leaving us with
an array of `SimpleCov::Result` objects. I tried the command on both
a recent result set and a result set from the last successful build:
the results were entirely the same, with both result sets returning
an array and triggering the same error, suggesting a code change for
this problem.

**For testing**

* Grab both result files from [CircleCI](https://app.circleci.com/pipelines/github/NetsoftHoldings/hubstaff-server/4139/workflows/f6e2ad8f-4c51-4302-bfc3-4131b02ec7bb/jobs/114303/artifacts)

* Run `bin/netsoft-circle merge resultset-0.json resultset-1.json`

* Confirm merge was successful