### PR TITLE
feat: fail instead of warn when PR base is not master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [0.4.1]
 ### Changed
 - exclude binary files in the grep calls
+- make PR base ~= master a hard error
 
 ## [0.4.0]
 ### Fixed

--- a/dangerfiles/pr.js
+++ b/dangerfiles/pr.js
@@ -28,7 +28,7 @@ if (!labels.includes('QA passed')) {
 }
 
 if (!danger.github.pr.base.ref.includes('master')) {
-  warn("PR base is not set to master!");
+  fail("PR base is not set to master!");
 }
 
 // Warn when there is a big PR


### PR DESCRIPTION
To make clearer and hopefully prevent accidental merges of nested PRs