### PR TITLE
fix: Exclude binary file from spec matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Next]
 ### Added
 ### Changed
-- exclude binary files in the grep calls
 ### Fixed
+
+## [0.4.1]
+### Changed
+- exclude binary files in the grep calls
 
 ## [0.4.0]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Next]
 ### Added
 ### Changed
+- exclude binary files in the grep calls
 ### Fixed
 
 ## [0.4.0]

--- a/Dangerfile
+++ b/Dangerfile
@@ -14,11 +14,11 @@ end
 
 # Don't let testing shortcuts get into master by accident
 if Dir.exist?('spec')
-  fail('fdescribe left in tests') if `grep -r -e '\\bfdescribe\\b' spec/ |grep -v 'danger ok' `.length > 1
-  fail('fcontext left in tests') if `grep -r -e '\\bfcontext\\b' spec/ |grep -v 'danger ok' `.length > 1
-  fail('fit left in tests') if `grep -r -e '\\bfit\\b' spec/ | grep -v 'danger ok' `.length > 1
-  fail('ap left in tests') if `grep -r -e '\\bap\\b' spec/ | grep -v 'danger ok' `.length > 1
-  fail('puts left in tests') if `grep -r -e '\\bputs\\b' spec/ | grep -v 'danger ok' `.length > 1
+  fail('fdescribe left in tests') if `grep -r -I -e '\\bfdescribe\\b' spec/ |grep -v 'danger ok' `.length > 1
+  fail('fcontext left in tests') if `grep -r -I -e '\\bfcontext\\b' spec/ |grep -v 'danger ok' `.length > 1
+  fail('fit left in tests') if `grep -r -I -e '\\bfit\\b' spec/ | grep -v 'danger ok' `.length > 1
+  fail('ap left in tests') if `grep -r -I -e '\\bap\\b' spec/ | grep -v 'danger ok' `.length > 1
+  fail('puts left in tests') if `grep -r -I -e '\\bputs\\b' spec/ | grep -v 'danger ok' `.length > 1
 end
 
 if File.exist?('Gemfile')

--- a/lib/netsoft-danger/version.rb
+++ b/lib/netsoft-danger/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module NetsoftDanger
-  VERSION = '0.4.0'
+  VERSION = '0.4.1'
 end


### PR DESCRIPTION
The real problem solved: `\bap\b` matched with some .jpg here: https://github.com/NetsoftHoldings/hubstaff-server/pull/5294
`-I` forces grep to exclude what it considers "binary" files.