### PR TITLE
feat: remove focused tests and print checks from Dangerfile

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -12,14 +12,6 @@ def toggle_label(github, label, should_set)
   end
 end
 
-# Don't let testing shortcuts get into master by accident
-if Dir.exist?('spec')
-  fail('fdescribe left in tests') if `grep -r -I -e '\\bfdescribe\\b' spec/ |grep -v 'danger ok' `.length > 1
-  fail('fcontext left in tests') if `grep -r -I -e '\\bfcontext\\b' spec/ |grep -v 'danger ok' `.length > 1
-  fail('ap left in tests') if `grep -r -I -e '\\bap\\b' spec/ | grep -v 'danger ok' `.length > 1
-  fail('puts left in tests') if `grep -r -I -e '\\bputs\\b' spec/ | grep -v 'danger ok' `.length > 1
-end
-
 if File.exist?('Gemfile')
   if `grep -r -e "^ *gem 'hubstaff_[a-z]\\+" Gemfile | grep -e ",.\\+[a-zA-Z]" `.length > 1
     fail('gemfile: Beta hubstaff_* gems are not allowed in master/production')


### PR DESCRIPTION

## Change description

- These are no longer needed as Rubocop is handling these now more accurately

## Related issues

- Source: <Issue link or Spec Link>
- UAT: <UAT Link>
- QA: <QA Task Link here>
- Review app: <Link to Heroku>

## Checklists

### Development

- [x] The commit message follows our [guidelines](https://docs.hubstaff.com/hubstaff-docs/latest/great_commit_messages.html)
- [x] I have performed a self-review of my own code
- [x] I have thoroughly tested the changes
- [x] I have added tests that prove my fix is effective or that my feature works

### Security

- [x] Security impact of change has been considered
