### PR TITLE
Adds less severity for WIP and Draft pull requests

### DIFF
--- a/dangerfiles/pr.js
+++ b/dangerfiles/pr.js
@@ -1,15 +1,34 @@
 import {danger, warn, fail, message} from "danger";
 
-if (!danger.github.issue.labels.length) {
-  fail('Please add labels to this PR');
-}
-
 var labels = danger.github.issue.labels.map(l => l.name);
 
-// Make it more obvious that a PR is a work in progress and shouldn't be merged yet
-if (labels.includes('work in progress') || danger.git.commits.find(c => c && c.message.includes('WIP'))) {
-  fail("PR is a Work in Progress");
+const draft = danger.github.pr.draft || labels.includes('work in progress') || danger.git.commits.find(c => c && c.message.includes('WIP'))
+
+const failNonDraft = (msg) =>  draft ? warn(msg) : fail(msg)
+
+if (!danger.github.issue.labels.length) {
+  failNonDraft('Please add labels to this PR');
 }
+
+// Make it more obvious that a PR is a work in progress and shouldn't be merged yet
+failNonDraft("PR is a Work in Progress");
+
+if (!(labels.includes('review passed') || labels.includes('code review passed'))) {
+  failNonDraft("Has not passed code review");
+}
+
+if (!labels.includes('QA passed')) {
+  failNonDraft("Has not passed QA");
+}
+
+// FIXME: Property 'milestone' does not exist on type 'GitHubPRDSL'.
+if (!danger.github.pr.milestone) {
+  failNonDraft('Requires a milestone before merging!');
+} else {
+  // we can do additional checks on the milestone name if we want.
+  // e.g. inspect milestone.title or milestone.description
+}
+
 
 if ((danger.github.pr.body || '').length < 5) {
   fail("Please provide a summary in the Pull Request description");
@@ -17,14 +36,6 @@ if ((danger.github.pr.body || '').length < 5) {
 
 if (labels.includes('product review needed')) {
   fail('Has not passed product review');
-}
-
-if (!(labels.includes('review passed') || labels.includes('code review passed'))) {
-  fail("Has not passed code review");
-}
-
-if (!labels.includes('QA passed')) {
-  fail("Has not passed QA");
 }
 
 if (!danger.github.pr.base.ref.includes('master')) {
@@ -43,11 +54,3 @@ if (danger.git.commits.find(c => c && c.message.match(/Merge branch/))) {
 if (danger.git.commits.find(c => c && c.message.match(/(fixup|squash)!/))) {
   fail("Contains a fixup or squash commit");
 }
-
-if (!danger.github.pr.milestone) {
-  fail('Requires a milestone before merging!');
-} else {
-  // we can do additional checks on the milestone name if we want.
-  // e.g. inspect milestone.title or milestone.description
-}
-


### PR DESCRIPTION
Let's see if this turns at least drafts green

## Change description

Instead of `fail` it will use `warn` for `draft` and `WIP` pull requests

- https://netsoftllc.slack.com/archives/C0N58QEJY/p1685124598562749?thread_ts=1685124180.425129&cid=C0N58QEJY
- https://netsoftllc.slack.com/archives/C0BLU0C9F/p1671068576984969?thread_ts=1671028884.389109&cid=C0BLU0C9F