### PR TITLE
Add validation of bundler version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,5 @@
 name: netsoft-danger-main
 
-
 on:
   pull_request:
   push:
@@ -8,48 +7,37 @@ on:
       - v[0-9]+.[0-9]+.[0-9]+.[0-9a-z]+
       - v[0-9]+.[0-9]+.[0-9]+
 
+env:
+  BUNDLE_PATH: vendor/bundle
+  RAILS_ENV: test
+  RUBYOPT: '-KU -E utf-8:utf-8'
 
 jobs:
-
   backend:
     name: Rubocop
     runs-on: [self-hosted, ubuntu-t3.medium]
-    container:
-      image: public.ecr.aws/q0j1f2t0/ruby:2.5.5-bionic
-      options: --user 1000
-      env:
-        BUNDLE_PATH: vendor/bundle
-        BUNDLE_VERSION: 1.17.3
-        BUNDLE_JOBS: 4
-        BUNDLE_RETRY: 3
-        RAILS_ENV: test
-        RUBYOPT: '-KU -E utf-8:utf-8'
-    
+
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - name: Install Bundler
+      # "cache-version" for the "ruby/setup-ruby" step should be bumped every time
+      # apt dependencies change
+      - name: Install dependencies
         shell: bash
         run: |
-          gem install bundler --version=$BUNDLE_VERSION --no-document
+          sudo apt-get -yq --no-install-recommends install \
+            build-essential
 
-      - uses: actions/cache@v2
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
         with:
-          path: |
-            vendor/bundle
-            Gemfile.lock
-          key: netsoft-danger-bundle-${{ hashFiles('Gemfile') }}-${{ hashFiles('netsoft-danger.gemspec') }}
-          restore-keys: |
-            netsoft-danger-bundle-${{ hashFiles('Gemfile') }}-${{ hashFiles('netsoft-danger.gemspec') }}
-            netsoft-danger-bundle-
+          ruby-version: 2.7.8
+          bundler-cache: true
+          bundler: 2.3.9
+          cache-version: 1.0
 
-      - name: 'Bundler install'
-        shell: bash
-        run: |
-          bundle _${BUNDLE_VERSION}_ check || bundle _${BUNDLE_VERSION}_ install --retry=$BUNDLE_RETRY
-
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: $HOME/.cache/rubocop_cache
           key: netsoft-danger-rubocop-${{ hashFiles('.rubocop.yml') }}
@@ -60,10 +48,7 @@ jobs:
       - name: Rubocop
         shell: bash
         run: |
-          bundle _${BUNDLE_VERSION}_ exec rubocop \
-            --parallel \
-            --format progress
-
+          bundle exec rubocop -P -f progress
 
   publish:
     name: Publish
@@ -71,24 +56,17 @@ jobs:
       github.event_name == 'push' && contains(github.ref, 'refs/tags/v')
     needs: [ backend ]
     runs-on: [self-hosted, ubuntu-t3.medium]
-    container:
-      image: public.ecr.aws/q0j1f2t0/ruby:2.5.5-bionic
-      options: --user 1000
-      env:
-        BUNDLE_PATH: vendor/bundle
-        BUNDLE_VERSION: 1.17.3
-        BUNDLE_JOBS: 4
-        BUNDLE_RETRY: 3
-        RAILS_ENV: test
-        RUBYOPT: '-KU -E utf-8:utf-8'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - name: Install Bundler
-        shell: bash
-        run: |
-          gem install bundler --version=$BUNDLE_VERSION --no-document
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7.8
+          bundler-cache: true
+          bundler: 2.3.9
+          cache-version: 1.0
 
       - name: Get Tag Name
         id: tag_name
@@ -129,50 +107,24 @@ jobs:
       github.event_name == 'pull_request' && always()
     needs: [ backend ]
     runs-on: [self-hosted, ubuntu-t3.medium]
-    container:
-      image: public.ecr.aws/q0j1f2t0/ruby:2.5.5-bionic
-      options: --user 1000
-      env:
-        BUNDLE_PATH: vendor/bundle
-        BUNDLE_VERSION: 1.17.3
-        BUNDLE_JOBS: 4
-        BUNDLE_RETRY: 3
-        RUBYOPT: '-KU -E utf-8:utf-8'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
-      - name: Install Bundler
-        shell: bash
-        run: |
-          gem install bundler --version=$BUNDLE_VERSION --no-document
-
-      - uses: actions/cache@v2
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
         with:
-          path: |
-            vendor/bundle
-            Gemfile.lock
-          key: netsoft-danger-bundle-${{ hashFiles('Gemfile') }}-${{ hashFiles('netsoft-danger.gemspec') }}
-          restore-keys: |
-            netsoft-danger-bundle-${{ hashFiles('Gemfile') }}-${{ hashFiles('netsoft-danger.gemspec') }}
-            netsoft-danger-bundle-
-
-      - name: Install Bundler
-        shell: bash
-        run: |
-          gem install bundler --version=$BUNDLE_VERSION --no-document
+          ruby-version: 2.7.8
+          bundler-cache: true
+          bundler: 2.3.9
+          cache-version: 1.0
 
       - name: Build Danger
         shell: bash
         run: |
           gem build *.gemspec
-
-      - name: 'Bundler install'
-        shell: bash
-        run: |
-          bundle _${BUNDLE_VERSION}_ check || bundle _${BUNDLE_VERSION}_ install --retry=$BUNDLE_RETRY
 
       - name: Run danger
         shell: bash

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ inherit_gem:
     - config/default.yml
 
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
 
 Style/SignalException:
   Exclude:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Next]
 ### Added
+- added check for bundler version in Gemfile.lock
 ### Changed
+- updated to bundler 2.3.9 for CI runs
 ### Fixed
 - silence intermittent error when removing a label
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Next]
 ### Added
+### Changed
+### Fixed
+
+## [0.8.0]
+### Added
 - added check for bundler version in Gemfile.lock
 ### Changed
 - updated to bundler 2.3.9 for CI runs

--- a/Dangerfile
+++ b/Dangerfile
@@ -26,6 +26,12 @@ if File.exist?('Gemfile')
   end
 end
 
+if File.exist?('Gemfile.lock')
+  if `grep -e "^BUNDLED WITH$" -A 1 Gemfile.lock | grep '    ' | grep -v "\(2\.3\.9\)"`.length > 1
+    fail('gemfile.lock: Gemfile was not bundled with approved bundler version. Please use 2.3.9')
+  end
+end
+
 if github.branch_for_head.start_with?('security')
   toggle_label(github, 'security', true)
 end

--- a/lib/netsoft-danger/version.rb
+++ b/lib/netsoft-danger/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module NetsoftDanger
-  VERSION = '0.7.0'
+  VERSION = '0.8.0'
 end

--- a/netsoft-danger.gemspec
+++ b/netsoft-danger.gemspec
@@ -13,12 +13,10 @@ Gem::Specification.new do |s|
   s.description = 'Packages a Dangerfile to be used with Danger.'
   s.executables << 'netsoft-circle'
 
-  s.files = `git ls-files`.split("\n").reject { |f|
-    f.match?(%r{^\.github/}i)
-  }
+  s.files = `git ls-files`.split("\n").grep_v(%r{^\.github/}i)
   s.require_paths = ['lib']
 
-  s.required_ruby_version = '>= 2.4'
+  s.required_ruby_version = '>= 2.5'
 
   s.add_runtime_dependency 'danger', '~> 8.0'
   s.add_runtime_dependency 'faraday'
@@ -27,5 +25,5 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rake'
 
-  s.add_development_dependency 'netsoft-rubocop', '= 1.1.2'
+  s.add_development_dependency 'netsoft-rubocop', '= 1.1.5'
 end


### PR DESCRIPTION
## Change description

Attempt to validate the bundler version in the Gemfile.lock

May cause false-positive errors on gems that are not using 2.3.9 (since we never check in the .lock file for gems)

## Related issues

- Source: https://netsoftllc.slack.com/archives/C0BLU0C9F/p1689699598079069?thread_ts=1689699438.586669&cid=C0BLU0C9F
- UAT: <UAT Link>
- QA: <QA Task Link here>
- Review app: <Link to Heroku>

## Checklists

### Development

- [x] The commit message follows our guidelines
- [x] I have performed a self-review of my own code
- [x] I have thoroughly tested the changes
- [ ] I have added tests that prove my fix is effective or that my feature works

### Security

- [x] Security impact of change has been considered