### PR TITLE
fix: Silence exception with intermittent labelling issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 ### Changed
 ### Fixed
+- silence intermittent error when removing a label
 
 ## [0.7.0]
 ### Changed

--- a/Dangerfile
+++ b/Dangerfile
@@ -10,6 +10,8 @@ def toggle_label(github, label, should_set)
   elsif !should_set && has_label
     github.api.remove_label(repo_name, pr_number, label)
   end
+rescue
+  # noop
 end
 
 if File.exist?('Gemfile')


### PR DESCRIPTION

## Change description

Sometimes danger can't set or unset a label usually when there are multiple instances running. This eats the error so it can continue with the other checks

## Related issues

- Source: <Issue link or Spec Link>
- UAT: <UAT Link>
- QA: <QA Task Link here>
- Review app: <Link to Heroku>

## Checklists

### Development

- [x] The commit message follows our [guidelines](https://docs.hubstaff.com/hubstaff-docs/latest/great_commit_messages.html)
- [x] I have performed a self-review of my own code
- [x] I have thoroughly tested the changes
- [x] I have added tests that prove my fix is effective or that my feature works

### Security

- [x] Security impact of change has been considered
